### PR TITLE
Added a secondary task with a when clause to differentiate between 'trusty' and 'xenial'

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,17 +1,17 @@
 ---
 - name: Install Packages | apt
   apt:
-    state: latest
-    pkg: "{{ item }}"
-  with_items:
-    - libzmq3
-    - libzmq3-dev
-  when: ansible_distribution_release == 'trusty'
+    state: latest
+    pkg: "{{ item }}"
+  with_items:
+    - libzmq3
+    - libzmq3-dev
+  when: ansible_distribution_release == 'trusty'
 
 - name: Install Packages | apt
-  apt:
-    state: latest
-    pkg: "{{ item }}"
-  with_items:
-    - libzmq5
-  when: ansible_distribution_release == 'xenial'
+  apt:
+    state: latest
+    pkg: "{{ item }}"
+  with_items:
+    - libzmq5
+  when: ansible_distribution_release == 'xenial'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,17 @@
 ---
 - name: Install Packages | apt
   apt:
-    state: latest
-    pkg: "{{ item }}"
-  with_items:
-    - libzmq3
-    - libzmq3-dev
-  tags:
-    - software-installation
-    - using-apt
+    state: latest
+    pkg: "{{ item }}"
+  with_items:
+    - libzmq3
+    - libzmq3-dev
+  when: ansible_distribution_release == 'trusty'
+
+- name: Install Packages | apt
+  apt:
+    state: latest
+    pkg: "{{ item }}"
+  with_items:
+    - libzmq5
+  when: ansible_distribution_release == 'xenial'


### PR DESCRIPTION
This commit will allow us to install zeromq (a requirement for our common install) on either Trusty (our current infra release) or Xenial (our new release that I'm currently transtioning over to)
